### PR TITLE
Update instructions to reflect 11 AM PST deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You are not allowed to collaborate during the Journal Entry. However, you are en
 
 We have allocated time on your schedule to ensure that you get this done at the end of each sprint.
 
-- For Full Time Students: Please submit your work on this journal entry before 11pm PST every Friday.
+- For Full Time Students: Please submit your work on this journal entry before 11 AM PST every Friday.
 - For Part Time Students: Please submit your work on this journal entry before the end of your B-Week Thursday class period.
 
 ## Template: Decision Defense


### PR DESCRIPTION
Instructions previously stated:
"- For Full Time Students: Please submit your work on this journal entry before 11 pm PST every Friday"

Corrected to:
"- For Full Time Students: Please submit your work on this journal entry before 11 AM PST every Friday."

The "Submitting your work" section at the bottom already correctly reflected 11 AM PST.